### PR TITLE
Gitignore globs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
+*.DS_Store
 node_modules/
 bower_components/
-db/test.db
-db/storage.db
+nedbstorage.db
+db/*.db
 .bin
-*.DS_Store
 app.nw
 db/datadump.csv
-db/dumpdbtocsv
+db/dumpdbtocsv.js
+*.swp

--- a/db/models/index.js
+++ b/db/models/index.js
@@ -21,7 +21,7 @@ var db = new DataStore({ filename: 'nedbstorage.db', autoload: true })
     // to do: gitignore glob path match 
     // also add .git to ignore 
     var globsToIgnore = gitignoreParse(gitIgnore);
-    globsToIgnore.push('.git');
+    globsToIgnore.push('**/.git/**');
     console.log('globs please', globsToIgnore);
     for (var i=0; i<globsToIgnore.length; i++) {
       if (minimatch(path.split(pwd)[1], globsToIgnore[i])) {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "angular": "^1.3.16",
     "angular-ui-router": "^0.2.15",
     "chokidar": "^1.0.2",
+    "gitignore-globs": "^0.1.1",
+    "minimatch": "^2.0.8",
     "nedb": "^1.1.2",
     "promisify-me": "^0.1.1",
     "sequelize": "^3.2.0",


### PR DESCRIPTION
Using the 'gitignore-globs' and 'minimatch' library, extract gitignore globs and compare to our files to prevent writing to db. Also ignores writing .git activity to db
